### PR TITLE
Support multiple paths in the SSM Environment Manager

### DIFF
--- a/flask_environment_manager/ssm_environment_manager.py
+++ b/flask_environment_manager/ssm_environment_manager.py
@@ -1,7 +1,7 @@
 import os
 import boto3
 
-from typing import Optional
+from typing import Optional, Union
 from flask import Flask
 from beautifultable import BeautifulTable
 from flask_environment_manager.whitelist_parser import WhitelistParser
@@ -11,19 +11,26 @@ class SsmEnvironmentManager:
     def __init__(
         self,
         app: Flask,
-        path: Optional[str] = None,
+        path: Optional[Union[str, list]] = [],
         region_name: Optional[str] = None,
         decrypt: bool = False,
     ):
         """
         Will read the AWS SSM access details from the app.config
         :param app: The Flask app instance
-        :param path: Path of the parameters in the SSM instance to read
+        :param path: Path of the parameters in the SSM instance to read. A string path or a list of paths.
         :param region_name: The region of the SSM instance. This will override the app.config value if provided.
         :param decrypt: If True, SecureString parameters are automatically decrypted.
         """
         self._app = app
-        self._path = path
+
+        self._path: list = []
+        if path is not None:
+            if type(path) is not list:
+                self._path = [path]
+            else:
+                self._path = list(path)
+
         self._decrypt = decrypt
 
         if self._app is not None:
@@ -52,7 +59,7 @@ class SsmEnvironmentManager:
 
         missing_params = []
         mismatched_params = []
-        ssm = self._get_ssm_values()
+        ssm = self._get_values_from_paths()
         for key in ssm.keys():
             missing = "YES"
             mismatch = "YES"
@@ -95,15 +102,26 @@ class SsmEnvironmentManager:
         """
         Load the SSM parameters into the Flask app config.
         """
-        ssm = self._get_ssm_values()
+        ssm = self._get_values_from_paths()
         WhitelistParser(self._app, ssm).parse()
 
-    def _get_ssm_values(self) -> dict:
+    def _get_values_from_paths(self) -> dict:
+        """
+        Iterate over the paths to build a value dict.
+        """
+        ssm: dict = {}
+        for path in self._path:
+            values = self._get_ssm_values(str(path))
+            ssm = {**ssm, **values}
+        return ssm
+
+    def _get_ssm_values(self, path: str) -> dict:
         """
         Get all values in a given path from SSM.
         The name of the keys in the return dict is the final
         part of the parameter path, e.g '/a/param/path' will
         be stored in the dict as 'path'
+        :param path: The path in SSM to read variables from
         :returns: A dict of parameter names and values.
         """
         client = boto3.client(
@@ -118,14 +136,14 @@ class SsmEnvironmentManager:
         while more_parameters:
             if ssm_repsonse.get("NextToken"):
                 ssm_repsonse = client.get_parameters_by_path(
-                    Path=self._path,
+                    Path=path,
                     Recursive=True,
                     NextToken=ssm_repsonse.get("NextToken"),
                     WithDecryption=self._decrypt,
                 )
             else:
                 ssm_repsonse = client.get_parameters_by_path(
-                    Path=self._path,
+                    Path=path,
                     Recursive=True,
                     WithDecryption=self._decrypt,
                 )

--- a/flask_environment_manager/ssm_environment_manager.py
+++ b/flask_environment_manager/ssm_environment_manager.py
@@ -52,22 +52,22 @@ class SsmEnvironmentManager:
 
         missing_params = []
         mismatched_params = []
-        ssm = self._get_parameters_from_paths()
-        for key in ssm.keys():
+        ssm_parameters = self._get_parameters_from_paths()
+        for key in ssm_parameters.keys():
             missing = "YES"
             mismatch = "YES"
             if key not in os.environ.keys():
                 missing_params.append(key)
                 missing = "NO"
 
-            if ssm[key] != os.environ.get(key):
+            if ssm_parameters[key] != os.environ.get(key):
                 mismatched_params.append(key)
                 mismatch = "NO"
 
             table.rows.append(
                 [
                     key,
-                    str(ssm.get(key)),
+                    str(ssm_parameters.get(key)),
                     str(os.environ.get(key)),
                     missing,
                     mismatch,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="flask-environment-manager",
-    version="2.1.0",
+    version="2.2.0",
     author="ScholarPack",
     author_email="dev@scholarpack.com",
     description="An environment manager for Flask, with support for whitelists and AWS SSM.",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,10 @@
 import pytest
+import os
+import boto3
 
-from typing import Generator
+from typing import Any, Generator
 from flask import Flask, Config
+from moto import mock_ssm
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -9,3 +12,52 @@ def app() -> Generator[Flask, None, None]:
     app = Flask(__name__)
     app.app_context().push()
     yield app
+
+
+@pytest.fixture(scope="module")
+def aws_credentials() -> None:
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+
+
+@pytest.fixture(scope="module")
+def ssm_client(aws_credentials: Any) -> Any:
+    with mock_ssm():
+        client = boto3.client("ssm", region_name="eu-west-2")
+        values = [
+            dict(
+                Name="/test",
+                Type="string",
+                Value="9ce10572-a1a4-422c-9cf1-d4b45ecd93c2",
+            ),
+            dict(
+                Name="/parent/child",
+                Type="string",
+                Value="27698a22-c47c-4457-a6b6-907051b4534a",
+            ),
+            dict(
+                Name="/a/1",
+                Type="string",
+                Value="49f48a53-e592-4bab-bf3a-7cfb08c584fb",
+            ),
+            dict(
+                Name="/a/2",
+                Type="string",
+                Value="ee11a634-5d43-4f16-a584-82752ce24591",
+            ),
+            dict(
+                Name="/b/3",
+                Type="string",
+                Value="fef47e26-b153-4ab8-a195-c7958e000491",
+            ),
+            dict(
+                Name="/c/2",
+                Type="string",
+                Value="e6c0fcf4-a67b-4375-a477-e7d72fce3420",
+            ),
+        ]
+        for value in values:
+            client.put_parameter(**value)
+        yield client

--- a/tests/test_ssm_environment_manager.py
+++ b/tests/test_ssm_environment_manager.py
@@ -13,8 +13,8 @@ class TestSsmEnvironmentManager:
         self, mock_client: Any, app: Flask, ssm_client: Any
     ) -> None:
         mock_client.return_value = ssm_client
-        env_man = SsmEnvironmentManager(app, "/", "eu-west-2")
-        data = env_man._get_ssm_values("/")
+        env_man = SsmEnvironmentManager(app, region_name="eu-west-2")
+        data = env_man._get_ssm_parameters("/")
         assert data == {
             "test": "9ce10572-a1a4-422c-9cf1-d4b45ecd93c2",
             "child": "27698a22-c47c-4457-a6b6-907051b4534a",
@@ -73,11 +73,11 @@ class TestSsmEnvironmentManager:
         ],
     )
     @patch(
-        "flask_environment_manager.ssm_environment_manager.SsmEnvironmentManager._get_ssm_values"
+        "flask_environment_manager.ssm_environment_manager.SsmEnvironmentManager._get_ssm_parameters"
     )
     def test_environment_comparisons(
         self,
-        mock_get_ssm_values: Any,
+        mock_get_ssm_parameters: Any,
         mock_config: Any,
         mock_value: dict,
         expected_missing: list,
@@ -85,32 +85,11 @@ class TestSsmEnvironmentManager:
         app: Flask,
     ) -> None:
         os.environ = mock_config
-        mock_get_ssm_values.return_value = mock_value
-        env_man = SsmEnvironmentManager(app, "/", "eu-west-2")
+        mock_get_ssm_parameters.return_value = mock_value
+        env_man = SsmEnvironmentManager(app, ["/"], "eu-west-2")
         res = env_man.compare_env_and_ssm()
         assert res.get("missing") == expected_missing
         assert res.get("mismatched") == expected_mismatched
-
-    @pytest.mark.parametrize(
-        "path, expected",
-        [
-            (
-                "/",
-                ["/"],
-            ),
-            (
-                ["/a", "/b"],
-                ["/a", "/b"],
-            ),
-            (
-                None,
-                [],
-            ),
-        ],
-    )
-    def test_constructor_path(self, path: Any, expected: Any, app: Flask) -> None:
-        env_man = SsmEnvironmentManager(app, path, "eu-west-2")
-        assert env_man._path == expected
 
     @patch("boto3.client")
     @pytest.mark.parametrize(
@@ -145,4 +124,4 @@ class TestSsmEnvironmentManager:
     ) -> None:
         mock_client.return_value = ssm_client
         env_man = SsmEnvironmentManager(app, path, "eu-west-2")
-        assert env_man._get_values_from_paths() == expected
+        assert env_man._get_parameters_from_paths() == expected

--- a/tests/test_ssm_environment_manager.py
+++ b/tests/test_ssm_environment_manager.py
@@ -1,37 +1,26 @@
 import os
-import boto3
 import pytest
 
 from typing import Any
 from unittest.mock import patch
 from flask import Flask
 from flask_environment_manager import SsmEnvironmentManager
-from moto import mock_ssm
-
-
-def setup_mock_ssm() -> None:
-    client = boto3.client("ssm", region_name="eu-west-2")
-    values = [
-        dict(Name="/test", Type="string", Value="9ce10572-a1a4-422c-9cf1-d4b45ecd93c2"),
-        dict(
-            Name="/parent/child",
-            Type="string",
-            Value="27698a22-c47c-4457-a6b6-907051b4534a",
-        ),
-    ]
-    for value in values:
-        client.put_parameter(**value)
 
 
 class TestSsmEnvironmentManager:
-    @mock_ssm
-    def test_building_value_dict(self, app: Flask) -> None:
-        setup_mock_ssm()
+    @patch("boto3.client")
+    def test_building_value_dict(
+        self, mock_client: Any, app: Flask, ssm_client: Any
+    ) -> None:
+        mock_client.return_value = ssm_client
         env_man = SsmEnvironmentManager(app, "/", "eu-west-2")
-        data = env_man._get_ssm_values()
+        data = env_man._get_ssm_values("/")
         assert data == {
             "test": "9ce10572-a1a4-422c-9cf1-d4b45ecd93c2",
             "child": "27698a22-c47c-4457-a6b6-907051b4534a",
+            "1": "49f48a53-e592-4bab-bf3a-7cfb08c584fb",
+            "2": "e6c0fcf4-a67b-4375-a477-e7d72fce3420",
+            "3": "fef47e26-b153-4ab8-a195-c7958e000491",
         }
 
     @pytest.mark.parametrize(
@@ -101,3 +90,59 @@ class TestSsmEnvironmentManager:
         res = env_man.compare_env_and_ssm()
         assert res.get("missing") == expected_missing
         assert res.get("mismatched") == expected_mismatched
+
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            (
+                "/",
+                ["/"],
+            ),
+            (
+                ["/a", "/b"],
+                ["/a", "/b"],
+            ),
+            (
+                None,
+                [],
+            ),
+        ],
+    )
+    def test_constructor_path(self, path: Any, expected: Any, app: Flask) -> None:
+        env_man = SsmEnvironmentManager(app, path, "eu-west-2")
+        assert env_man._path == expected
+
+    @patch("boto3.client")
+    @pytest.mark.parametrize(
+        "path, expected",
+        [
+            (
+                ["/a", "/b"],
+                {
+                    "1": "49f48a53-e592-4bab-bf3a-7cfb08c584fb",
+                    "2": "ee11a634-5d43-4f16-a584-82752ce24591",
+                    "3": "fef47e26-b153-4ab8-a195-c7958e000491",
+                },
+            ),
+            (
+                ["/a", "/c"],
+                {
+                    "1": "49f48a53-e592-4bab-bf3a-7cfb08c584fb",
+                    "2": "e6c0fcf4-a67b-4375-a477-e7d72fce3420",
+                },
+            ),
+            (
+                ["/c", "/a"],
+                {
+                    "1": "49f48a53-e592-4bab-bf3a-7cfb08c584fb",
+                    "2": "ee11a634-5d43-4f16-a584-82752ce24591",
+                },
+            ),
+        ],
+    )
+    def test_loading_multiple_paths(
+        self, mock_client: Any, path: Any, expected: Any, app: Flask, ssm_client: Any
+    ) -> None:
+        mock_client.return_value = ssm_client
+        env_man = SsmEnvironmentManager(app, path, "eu-west-2")
+        assert env_man._get_values_from_paths() == expected


### PR DESCRIPTION
This change will allow a list of paths to be provided and will load all the variables into one dict.

Any clashing parameters will be overwritten with the last path used being the one that is kept.

I am really interested in reviews around the SsmEnvironmentManager constructor and my handling of the possible non-list. Is this pythonic? Is the okay? Suggestions?

**Pytest Changes**
Now, instead of generating a new client in the test, we generate it as part of the pytest fixtures and mock it in the tests we want to use it in. This is okay as we will only ever be reading from boto3, not writing.